### PR TITLE
🔧 :: GW-160 PostFootstep 피쳐 TCA 최신 패턴으로 리팩토링

### DIFF
--- a/Projects/Feature/RecordFeature/Sources/CaptureImageView.swift
+++ b/Projects/Feature/RecordFeature/Sources/CaptureImageView.swift
@@ -22,61 +22,59 @@ public struct CaptureImageView: View {
     }
     
     public var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack {
-                HStack {
-                    Spacer()
-                    
-                    Button(
-                        action: {
-                            store.send(.dismissButtonTapped)
-                        },
-                        label: {
-                            Image(systemName: "xmark")
-                                .font(.title)
-                                .tint(.white)
-                        }
-                    )
-                    
-                }
-                .padding(.top, 30)
-                .padding(.trailing, 30)
-                .padding(.bottom, 50)
+        VStack {
+            HStack {
+                Spacer()
                 
-                viewFinderView(viewStore: viewStore)
-                
-                buttonsView(viewStore: viewStore)
-            }
-            .background(Color.black)
-            .onAppear {
-                viewStore.send(.viewWillAppear)
-            }
-            .fullScreenCover(
-                store: self.store.scope(
-                    state: \.$cameraResult,
-                    action: \.cameraResult
+                Button(
+                    action: {
+                        store.send(.dismissButtonTapped)
+                    },
+                    label: {
+                        Image(systemName: "xmark")
+                            .font(.title)
+                            .tint(.white)
+                    }
                 )
-            ) { postFootstepFeature in
-                NavigationStack {
-                    PostFootstepView(store: postFootstepFeature)
-                }
+                
             }
-            .transaction { transaction in
-                transaction.disablesAnimations = viewStore.disableDismissAnimation
+            .padding(.top, 30)
+            .padding(.trailing, 30)
+            .padding(.bottom, 50)
+            
+            viewFinder
+            
+            buttonsView
+        }
+        .background(Color.black)
+        .onAppear {
+            store.send(.viewWillAppear)
+        }
+        .fullScreenCover(
+            store: self.store.scope(
+                state: \.$cameraResult,
+                action: \.cameraResult
+            )
+        ) { postFootstepFeature in
+            NavigationStack {
+                PostFootstepView(store: postFootstepFeature)
             }
+        }
+        .transaction { transaction in
+            transaction.disablesAnimations = store.disableDismissAnimation
         }
     }
     
-    private func viewFinderView(viewStore: CameraFeatureViewStore) -> some View {
+    private var viewFinder: some View {
         GeometryReader { geometry in
             ZStack {
-                if let image = viewStore.state.viewFinderImage {
+                if let image = store.state.viewFinderImage {
                     image
                         .resizable()
                         .scaledToFit()
                 }
                 
-                if let flipImage = viewStore.state.flipImage {
+                if let flipImage = store.state.flipImage {
                     flipImage
                         .resizable()
                         .scaledToFit()
@@ -85,16 +83,16 @@ public struct CaptureImageView: View {
             }
             .frame(width: geometry.size.width, height: geometry.size.width * CameraSetting.ratio)
             .background(Color.clear)
-            .rotation3DEffect(.degrees(viewStore.state.flipDegree), axis: (x: 0, y: 1, z: 0))
+            .rotation3DEffect(.degrees(store.state.flipDegree), axis: (x: 0, y: 1, z: 0))
         }
     }
     
-    private func buttonsView(viewStore: CameraFeatureViewStore) -> some View {
+    private var buttonsView: some View {
         HStack {
             Spacer()
             
             Button {
-                viewStore.send(.shutterTapped)
+                store.send(.shutterTapped)
             } label: {
                 ZStack {
                     Circle()

--- a/Projects/Feature/RecordFeature/Sources/PostFootstepView.swift
+++ b/Projects/Feature/RecordFeature/Sources/PostFootstepView.swift
@@ -8,69 +8,62 @@
 
 import CameraInterface
 import ComposableArchitecture
+import DesignSystem
 import SwiftUI
 
 public struct PostFootstepView: View {
     typealias CameraResultViewStore = ViewStore<PostFootstepFeature.State, PostFootstepFeature.Action>
         
-    let store: StoreOf<PostFootstepFeature>
-    
-    
+    @Bindable var store: StoreOf<PostFootstepFeature>
     
     public var body: some View {
-        WithViewStore(self.store, observe: \.self) { viewStore in
-            NavigationStack {
-                GeometryReader { geometry in
-                    VStack {
-                        Spacer()
-                        
-                        viewStore.resultImage
-                            .resizable()
-                            .scaledToFit()
-                            .frame(
-                                width: geometry.size.width,
-                                height: geometry.size.width * CameraSetting.ratio)
-                            .background(Color.white)
-                        
-                        Spacer()
-                        
-                        TextField(
-                            "(선택) 오늘의 한 마디를 남겨주세요 :)",
-                            text: viewStore.binding(
-                                get: \.todaysMessage,
-                                send: PostFootstepFeature.Action.todaysMessageChanged
-                            )
-                        )
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .padding(.horizontal, 35)
-                        
-                        buttonsView(viewStore: viewStore)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 45)
-                            .padding(.horizontal, 45)
-                        
-                        Spacer()
-                    }
-                    .background(Color.white)
+        NavigationStack {
+            GeometryReader { proxy in
+                VStack {
+                    Spacer()
                     
+                    store.resultImage
+                        .resizable()
+                        .scaledToFit()
+                        .frame(
+                            width: proxy.size.width,
+                            height: proxy.size.width * CameraSetting.ratio)
+                        .background(Color.white)
+                    
+                    Spacer()
+                    
+                    TextField(
+                         "(선택) 오늘의 한 마디를 남겨주세요 :)",
+                         text: $store.todaysMessage
+                     )
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal, 35)
+                    
+                    buttonsView
+                        .frame(height: 100)
+                        .padding(.horizontal, 45)
+                    
+                    Spacer()
                 }
-                .navigationTitle("발자취")
+                .background(Color.white)
             }
+            .navigationTitle("발자취")
         }
     }
     
-    private func buttonsView(viewStore: CameraResultViewStore) -> some View {
+    private var buttonsView: some View {
         HStack(spacing: 10) {
             Button {
-                viewStore.send(.saveButtonTapped)
+                store.send(.saveButtonTapped)
             } label: {
                 Text("남기기 😽")
             }
+            .tint(DesignSystemAsset.Colors.accentColor.swiftUIColor)
             .buttonStyle(.borderedProminent)
             
             
             Button {
-                viewStore.send(.cancelButtonTapped)
+                store.send(.cancelButtonTapped)
             } label: {
                 Text("취소")
             }


### PR DESCRIPTION
- PostFootstepFeature를 @ObservableState 및 BindableAction으로 업데이트
- PostFootstepView에서 @Bindable var store 패턴 적용
- todaysMessageChanged 액션을 binding으로 대체하여 간소화
- 문자 제한 로직을 binding case에서 처리하도록 개선
- WithViewStore 제거로 최신 TCA 패턴 적용
- CaptureImageView도 @Bindable 패턴으로 업데이트

🤖 Generated with [Claude Code](https://claude.ai/code)