### PR TITLE
🐛 :: GW-182 회원 탈퇴 후 로그인 화면으로 다시 이동하도록

### DIFF
--- a/Projects/App/Sources/Application/RootFeature.swift
+++ b/Projects/App/Sources/Application/RootFeature.swift
@@ -27,6 +27,7 @@ public struct RootFeature {
     public enum Action {
         case signIn(SignInFeature.Action)
         case mainTab(MainTabFeature.Action)
+        case logout
     }
     
     public init() {}
@@ -37,12 +38,19 @@ public struct RootFeature {
             case .signIn(.isAlreadyAuthorized):
                 state.isSignIn = true
                 return .none
-                
+
+            case .mainTab(.delegate(.userDidLogout)):
+                return .send(.logout)
+
+            case .logout:
+                state.isSignIn = false
+                return .none
+
             default:
                 return .none
             }
         }
-        
+
         Scope(state: \.mainTab, action: \.mainTab) {
             MainTabFeature()
         }

--- a/Projects/Feature/MainFeature/Sources/MainTabFeature.swift
+++ b/Projects/Feature/MainFeature/Sources/MainTabFeature.swift
@@ -29,10 +29,15 @@ public struct MainTabFeature {
     
     public enum Action {
         case selectTab(MainTab)
-        
+
         case feed(FeedFeature.Action)
         case profile(ProfileFeature.Action)
         case usingCamera(PresentationAction<CaptureImageFeature.Action>)
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case userDidLogout
+        }
     }
     
     public init() {}
@@ -66,7 +71,13 @@ public struct MainTabFeature {
                 state.usingCamera = nil
                 state.currentTab = state.previousTab
                 return .none
-                
+
+            case .profile(.delegate(.userDidLogout)):
+                return .send(.delegate(.userDidLogout))
+
+            case .delegate:
+                return .none
+
             default:
                 return .none
             }

--- a/Projects/Feature/ProfileFeature/Sources/ProfileFeature.swift
+++ b/Projects/Feature/ProfileFeature/Sources/ProfileFeature.swift
@@ -27,6 +27,11 @@ public struct ProfileFeature {
         case fetchProfile(Profile)
         case path(StackAction<Path.State, Path.Action>)
         case navigateToSettings
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case userDidLogout
+        }
     }
     
     @Reducer(state: .equatable)
@@ -50,12 +55,18 @@ public struct ProfileFeature {
             case .fetchProfile(let profile):
                 state.profile = profile
                 return .none
-                
+
+            case .path(.element(id: _, action: .settings(.delegate(.userDidLogout)))):
+                return .send(.delegate(.userDidLogout))
+
             case .path:
                 return .none
-                
+
             case .navigateToSettings:
                 state.path.append(.settings(SettingsFeature.State()))
+                return .none
+
+            case .delegate:
                 return .none
             }
         }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsFeature.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsFeature.swift
@@ -30,10 +30,15 @@ public struct SettingsFeature {
         case showDeleteAlert
         case alert(PresentationAction<Alert>)
         case withdrawUserSuccess
-        
+        case delegate(Delegate)
+
         @CasePathable
         public enum Alert {
             case confirmDeleteAccount
+        }
+
+        public enum Delegate {
+            case userDidLogout
         }
     }
     
@@ -91,13 +96,15 @@ public struct SettingsFeature {
                 
             case .withdrawUserSuccess:
                 state.isLoading = false
-                // Force app to restart or navigate to login screen
-                // This will be handled by parent feature detecting token absence
-                return .run { _ in
+                return .run { send in
+                    await send(.delegate(.userDidLogout))
                     await dismiss()
                 }
                 
             case .alert:
+                return .none
+
+            case .delegate:
                 return .none
             }
         }


### PR DESCRIPTION
- Delegate 패턴을 사용한 계층적 로그아웃 이벤트 전파
- SettingsFeature → ProfileFeature → MainTabFeature → RootFeature
- 토큰 삭제 후 isSignIn = false 설정으로 로그인 화면 전환
- SignInFeature 코드 스타일 개선 (run effect 명시적 파라미터)